### PR TITLE
New builder invalidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "^3.10.1"
   },
   "devDependencies": {
+    "chokidar": "^1.2.0",
     "jspm": "^0.16.11"
   },
   "jspm": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.1",
-    "jspm": "^0.16.10",
+    "jspm": "^0.16.12",
     "lodash": "^3.10.1"
   },
   "devDependencies": {

--- a/test-project/build.js
+++ b/test-project/build.js
@@ -1,5 +1,6 @@
 var DevBuilder = require('../index');
 var path = require('path');
+var chokidar = require('chokidar');
 
 var appBuilder = new DevBuilder({
   jspm: require('jspm'),
@@ -12,3 +13,8 @@ var appBuilder = new DevBuilder({
 });
 
 appBuilder.build();
+
+chokidar.watch('main.js').on('change', function() {
+  appBuilder.build('main.js');
+});
+

--- a/test-project/main.js
+++ b/test-project/main.js
@@ -4,7 +4,7 @@ import { testThing } from './test-module';
 testThing();
 
 $(() => {
-  $('body').css('background-color', 'red');
+  $('body').css('background-color', 'blue');
 });
 
 

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -1,0 +1,12 @@
+{
+  "jspm": {
+    "dependencies": {
+      "jquery": "github:components/jquery@^2.1.4"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.8.24",
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4"
+    }
+  }
+}


### PR DESCRIPTION
@guybedford @OliverJAsh this branch uses 0.16.12 of jspm and hence also the newest SystemJS-Builder with cache invalidation. Be great to get your eyes over this :)
