### PR TITLE
Improve error output

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ DevBuilder.prototype.build = function(filename) {
     this.logInfo('jspm build finished', chalk.red(buildEnd - buildStart));
     return this;
   }.bind(this)).catch(function(err) {
-    // Do any errors actually contain an error property?
+    // Do any errors actually contain a message property?
     if (err.message) {
         this.logError('jspm build error:', err.message, err.stack);
     }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,13 @@ DevBuilder.prototype.build = function(filename) {
     this.logInfo('jspm build finished', chalk.red(buildEnd - buildStart));
     return this;
   }.bind(this)).catch(function(err) {
-    this.logError('jspm build error', err.message, err.stack);
+    // Do any errors actually contain an error property?
+    if (err.message) {
+        this.logError('jspm build error:', err.message, err.stack);
+    }
+    else {
+        this.logError('jspm build error:', err);
+    }
   }.bind(this));
 };
 


### PR DESCRIPTION
Hi, 

I noticed that (at least in my case) not all errors contain a message and stack property.  This PR improves the output, providing more information when an error occurs that doesn't contain a message property.

Before this fix:

```
jspm-app jspm build error undefined undefined
```

After this fix:

```
jspm-app jspm build error: SyntaxError: Unexpected token ?
    Evaluating file:///Users/karl.purkhardt/projects/x/www/app/app.component.ts
    Error on instantiate for app/app.component.ts at file:///Users/karl.purkhardt/projects/x/www/app/app.component.ts
    Loading app/boot.ts
```
